### PR TITLE
Handles a hash with delegate

### DIFF
--- a/lib/yard-activerecord/delegations/delegate_handler.rb
+++ b/lib/yard-activerecord/delegations/delegate_handler.rb
@@ -13,6 +13,7 @@ module YARD::Handlers::Ruby::ActiveRecord::Delegations
       class_name = options.detect { |v| v =~ /to\:\s|\:to \=\>/ } unless options.length == 0
       class_name = class_name.to_s.gsub(/\A.*\:/,'').capitalize
       params.each do |method_name|
+        method_name.gsub!(/[\:\'\"]/,'')
         object = YARD::CodeObjects::MethodObject.new(namespace, method_name)
         object.group = "Delegated Instance Attributes"
         object.docstring = "Alias for {#{class_name}##{method_name}}"


### PR DESCRIPTION
Not sure if delegate was working and has just changed, or it was never tested, but this fixes it so the result refers to the actual class being delegated to.

Before, it would always say:

```
To#email
To#street
```

Now, it says

```
Actor#email
Address#street
```
