### PR TITLE
Fix Typo - r_object to rw_object

### DIFF
--- a/lib/yard-activerecord/fields/field_handler.rb
+++ b/lib/yard-activerecord/fields/field_handler.rb
@@ -28,7 +28,7 @@ module YARD::Handlers::Ruby::ActiveRecord::Fields
         rw_object.docstring.add_tag get_tag(:return, '', class_name)
         rw_object.dynamic = true
         register rw_object
-        method_definition[rw] = r_object
+        method_definition[rw] = rw_object
       end
 
       namespace.instance_attributes[method_name.to_sym] = method_definition


### PR DESCRIPTION
```
[error]: Unhandled exception in YARD::Handlers::Ruby::ActiveRecord::Fields::FieldHandler:
[error]:   in `db/schema.rb`:314:

    314: t.string   "status",        :limit => 10, :scale => 0

[error]: NameError: undefined local variable or method `r_object' for #<YARD::Handlers::Ruby::ActiveRecord::Fields::FieldHandler:0x000000068c36f0>
[error]: Stack trace:
    /home/ray/.rvm/gems/ruby-2.0.0-p195/bundler/gems/yard-activerecord-3814b8bc0721/lib/yard-activerecord/fields/field_handler.rb:31:in `block in process'
    /home/ray/.rvm/gems/ruby-2.0.0-p195/bundler/gems/yard-activerecord-3814b8bc0721/lib/yard-activerecord/fields/field_handler.rb:24:in `each'
    /home/ray/.rvm/gems/ruby-2.0.0-p195/bundler/gems/yard-activerecord-3814b8bc0721/lib/yard-activerecord/fields/field_handler.rb:24:in `process'
    /home/ray/.rvm/gems/ruby-2.0.0-p195/gems/yard-0.8.7/lib/yard/handlers/processor.rb:114:in `block (2 levels) in process'
    /home/ray/.rvm/gems/ruby-2.0.0-p195/gems/yard-0.8.7/lib/yard/handlers/processor.rb:112:in `each'
    /home/ray/.rvm/gems/ruby-2.0.0-p195/gems/yard-0.8.7/lib/yard/handlers/processor.rb:112:in `block in process'
```
