### PR TITLE
Change Array<T> return types to ActiveRecord::Relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The documentation will then be skipped for this table/class.
 The plugin handles `has_one`, `belongs_to`, `has_many` and
 `has_and_belongs_to_many` associations. The annotation for each association
 includes a link to the referred model. For associations with a list of objects
-the documentation will simply be marked as `Array<ModelName>`.
+the documentation will simply be marked as `ActiveRecord::Relation<ModelName>`.
 
 ## Delegates
 

--- a/lib/yard-activerecord/associations/plural_handler.rb
+++ b/lib/yard-activerecord/associations/plural_handler.rb
@@ -3,12 +3,12 @@ require_relative 'base'
 module YARD::Handlers::Ruby::ActiveRecord::Associations
   class PluralHandler < Base
     def class_name
-      "Array<#{super(true)}>"
+      "ActiveRecord::Relation<#{super(true)}>"
     end
 
     private
     def return_description
-      "An array of associated #{method_name.humanize}"
+      "A relationship to the associated #{method_name.humanize} that can have further scopes chained on it or converted to an array with #to_a"
     end
   end
 end

--- a/lib/yard-activerecord/scopes/scope_handler.rb
+++ b/lib/yard-activerecord/scopes/scope_handler.rb
@@ -19,13 +19,13 @@ module YARD::Handlers::Ruby::ActiveRecord::Scopes
     end
     
     def return_description
-      "An array of #{ActiveSupport::Inflector.pluralize namespace.to_s} " +
+      "A relation of #{ActiveSupport::Inflector.pluralize namespace.to_s} " +
       "that are #{method_name.split('_').join(' ')}. " +
       "<strong>Active Record Scope</strong>"
     end
     
     def class_name
-      "Array<#{namespace}>"
+      "ActiveRecord::Relation<#{namespace}>"
     end
 
     def get_tag(tag, text, return_classes = [],name=nil)


### PR DESCRIPTION
Plural associations and scopes don't return `Array`, they return `ActiveRecord::Relation`s.  `ActiveRecord::Relation`s allow chaining queries and scopes, actual `Array`s do not, so it is better to mark the return type as `ActiveRecord::Relation<model>` instead of `Array<model>`.  Additionally, in new Rails (4+), the returned `ActiveRecord::Relation` doesn't even work as a pseudo-Array, you have to call `to_a` to get an `ActiveRecord::Relation` to perform a query.

# Before
## has_many
![screen shot 2015-04-30 at 9 10 06 am](https://cloud.githubusercontent.com/assets/2230482/7414508/e30ed676-ef18-11e4-8217-0ba38c916caf.png)

## scopes
![screen shot 2015-04-30 at 9 10 28 am](https://cloud.githubusercontent.com/assets/2230482/7414500/d4891dbe-ef18-11e4-95f0-873e1aedc3c4.png)

# After
## has_many
![screen shot 2015-04-30 at 9 21 56 am](https://cloud.githubusercontent.com/assets/2230482/7414780/61a93aac-ef1a-11e4-8569-f66ac164f349.png)

## scopes
![screen shot 2015-04-30 at 9 21 34 am](https://cloud.githubusercontent.com/assets/2230482/7414783/673da534-ef1a-11e4-91ef-3068d929ce3d.png)
