### PR TITLE
Update delegate_handler.rb

### DIFF
--- a/lib/yard-activerecord/delegations/delegate_handler.rb
+++ b/lib/yard-activerecord/delegations/delegate_handler.rb
@@ -22,7 +22,7 @@ module YARD::Handlers::Ruby::ActiveRecord::Delegations
         method_name.gsub!(/[\:\'\"]/,'')
         original_method_name = method_name.dup
 
-        unless prefix_name.length == 0
+        if prefix_name&.length&.> 0
           prefix_name = class_name.downcase if prefix_name == 'true'
           method_name.prepend("#{prefix_name}_")
         end


### PR DESCRIPTION
I was receiving an error when generating documentation that included delegation methods within decorator classes (specifically from the Draper gem). The error was caused by `undefined method "length" for nil`. This patch fixes the problem with the lightest touch possible.